### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.Cors.Core/CorsOptions.cs
+++ b/src/Microsoft.AspNet.Cors.Core/CorsOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Cors.Core
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 _defaultPolicyName = value;

--- a/src/Microsoft.AspNet.Cors.Core/CorsPolicy.cs
+++ b/src/Microsoft.AspNet.Cors.Core/CorsPolicy.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.Cors.Core
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentOutOfRangeException("value", Resources.PreflightMaxAgeOutOfRange);
+                    throw new ArgumentOutOfRangeException(nameof(value), Resources.PreflightMaxAgeOutOfRange);
                 }
 
                 _preflightMaxAge = value;

--- a/src/Microsoft.AspNet.Cors.Core/CorsResult.cs
+++ b/src/Microsoft.AspNet.Cors.Core/CorsResult.cs
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Cors.Core
             {
                 if (value < TimeSpan.Zero)
                 {
-                    throw new ArgumentOutOfRangeException("value", Resources.PreflightMaxAgeOutOfRange);
+                    throw new ArgumentOutOfRangeException(nameof(value), Resources.PreflightMaxAgeOutOfRange);
                 }
                 _preflightMaxAge = value;
             }


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason