### PR TITLE
Make preflight request header check case-insensitive

### DIFF
--- a/src/Microsoft.AspNet.Cors.Core/CorsService.cs
+++ b/src/Microsoft.AspNet.Cors.Core/CorsService.cs
@@ -95,7 +95,8 @@ namespace Microsoft.AspNet.Cors.Core
 
             if (!policy.AllowAnyHeader &&
                 requestHeaders != null &&
-                !requestHeaders.All(header => policy.Headers.Contains(header, StringComparer.Ordinal)))
+                !requestHeaders.All(header => CorsConstants.SimpleRequestHeaders.Contains(header, StringComparer.OrdinalIgnoreCase) ||
+                                              policy.Headers.Contains(header, StringComparer.OrdinalIgnoreCase)))
             {
                 return;
             }

--- a/test/Microsoft.AspNet.Cors.Core.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNet.Cors.Core.Test/CorsServiceTests.cs
@@ -396,7 +396,7 @@ namespace Microsoft.AspNet.Cors.Core.Test
                 method: "OPTIONS",
                 origin: "http://example.com",
                 accessControlRequestMethod: "PUT",
-                accessControlRequestHeaders: new[] { "Content-Type" });
+                accessControlRequestHeaders: new[] { "content-type", "accept" });
             var policy = new CorsPolicy();
             policy.Origins.Add(CorsConstants.AnyOrigin);
             policy.Methods.Add("*");
@@ -408,8 +408,8 @@ namespace Microsoft.AspNet.Cors.Core.Test
             var result = corsService.EvaluatePolicy(requestContext, policy);
 
             // Assert
-            Assert.Equal(1, result.AllowedHeaders.Count);
-            Assert.Contains("Content-Type", result.AllowedHeaders);
+            Assert.Equal(2, result.AllowedHeaders.Count);
+            Assert.Contains("Content-Type", result.AllowedHeaders, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]


### PR DESCRIPTION
In jquery ajax(maybe in old versions), the `Access-Control-Request-Headers` in `OPTIONS` request value is lower case and will contains `accept` header which is already in `SimpleRequestHeaders`