### PR TITLE
React to HttpAbstractions namespace changes

### DIFF
--- a/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Cors.Infrastructure

--- a/test/Microsoft.AspNetCore.Cors.Test/DefaultCorsPolicyProviderTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/DefaultCorsPolicyProviderTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Cors.Infrastructure
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             };
             var policyProvider = new DefaultCorsPolicyProvider(corsOptions);
 
-            // Act 
+            // Act
             var actualPolicy = await policyProvider.GetPolicyAsync(new DefaultHttpContext(), policyName: null);
 
             // Assert
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             };
             var policyProvider = new DefaultCorsPolicyProvider(corsOptions);
 
-            // Act 
+            // Act
             var actualPolicy = await policyProvider.GetPolicyAsync(new DefaultHttpContext(), policyName);
 
             // Assert


### PR DESCRIPTION
- aspnet/HttpAbstractions#549 and aspnet/HttpAbstractions#592
- clean up `using`s