### PR TITLE
Ability to allow cors on wildcard subdomain matches like so...

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+    <clear />
+    <add key="AspNetVNext" value="https://www.myget.org/f/aspnetmaster/api/v3/index.json" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/global.json
+++ b/global.json
@@ -1,3 +1,9 @@
 {
-    "projects": ["src", "test"]
+  "projects": [
+    "src",
+    "test"
+  ],
+  "sdk": {
+    "version": "1.0.0-rc1-final"
+  }
 }

--- a/samples/UseOptions/project.json
+++ b/samples/UseOptions/project.json
@@ -1,30 +1,30 @@
 {
-    "webroot": "wwwroot",
-    "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.AspNet.Cors": "6.0.0-*",
-        "Microsoft.AspNet.Diagnostics": "1.0.0-*",
-        "Microsoft.AspNet.Server.IIS": "1.0.0-*",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
-        "Microsoft.Extensions.Logging.Console": "1.0.0-*"
-    },
-    "commands": {
-        "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000"
-    },
-    "frameworks": {
-        "dnx451": {},
-        "dnxcore50": {}
-    },
-    "publishExclude": [
-        "node_modules",
-        "bower_components",
-        "**.kproj",
-        "**.user",
-        "**.vspscc"
-    ],
-    "exclude": [
-        "wwwroot",
-        "node_modules",
-        "bower_components"
-    ]
+  "webroot": "wwwroot",
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
+    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
+    "Microsoft.AspNet.Server.IIS": "1.0.0-*",
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final"
+  },
+  "commands": {
+    "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000"
+  },
+  "frameworks": {
+    "dnx451": {},
+    "dnxcore50": {}
+  },
+  "publishExclude": [
+    "node_modules",
+    "bower_components",
+    "**.kproj",
+    "**.user",
+    "**.vspscc"
+  ],
+  "exclude": [
+    "wwwroot",
+    "node_modules",
+    "bower_components"
+  ]
 }

--- a/samples/UsePolicyBuilder/project.json
+++ b/samples/UsePolicyBuilder/project.json
@@ -1,30 +1,30 @@
 {
-    "webroot": "wwwroot",
-    "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.AspNet.Cors": "6.0.0-*",
-        "Microsoft.AspNet.Diagnostics": "1.0.0-*",
-        "Microsoft.AspNet.Server.IIS": "1.0.0-*",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
-        "Microsoft.Extensions.Logging.Console": "1.0.0-*"
-    },
-    "commands": {
-        "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000"
-    },
-    "frameworks": {
-        "dnx451": {},
-        "dnxcore50": {}
-    },
-    "publishExclude": [
-        "node_modules",
-        "bower_components",
-        "**.kproj",
-        "**.user",
-        "**.vspscc"
-    ],
-    "exclude": [
-        "wwwroot",
-        "node_modules",
-        "bower_components"
-    ]
+  "webroot": "wwwroot",
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
+    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
+    "Microsoft.AspNet.Server.IIS": "1.0.0-*",
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final"
+  },
+  "commands": {
+    "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000"
+  },
+  "frameworks": {
+    "dnx451": {},
+    "dnxcore50": {}
+  },
+  "publishExclude": [
+    "node_modules",
+    "bower_components",
+    "**.kproj",
+    "**.user",
+    "**.vspscc"
+  ],
+  "exclude": [
+    "wwwroot",
+    "node_modules",
+    "bower_components"
+  ]
 }

--- a/src/Microsoft.AspNet.Cors/CorsService.cs
+++ b/src/Microsoft.AspNet.Cors/CorsService.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.Cors.Infrastructure
         public virtual void EvaluateRequest(HttpContext context, CorsPolicy policy, CorsResult result)
         {
             var origin = context.Request.Headers[CorsConstants.Origin];
-            if (StringValues.IsNullOrEmpty(origin) || !policy.AllowAnyOrigin && !policy.Origins.Contains(origin))
+            if (!OriginIsAllowed(origin, policy))
             {
                 return;
             }
@@ -95,7 +95,7 @@ namespace Microsoft.AspNet.Cors.Infrastructure
         public virtual void EvaluatePreflightRequest(HttpContext context, CorsPolicy policy, CorsResult result)
         {
             var origin = context.Request.Headers[CorsConstants.Origin];
-            if (StringValues.IsNullOrEmpty(origin) || !policy.AllowAnyOrigin && !policy.Origins.Contains(origin))
+            if (!OriginIsAllowed(origin, policy))
             {
                 return;
             }
@@ -214,6 +214,17 @@ namespace Microsoft.AspNet.Cors.Infrastructure
             }
         }
 
+        protected virtual bool OriginIsAllowed(string origin, CorsPolicy policy)
+        {
+            if (!string.IsNullOrWhiteSpace(origin) && 
+                (policy.AllowAnyOrigin ||
+                 policy.Origins.Contains(origin) ||
+                 IsWildCardSubdomainMatch(origin, policy)))
+                return true;
+
+            return false;
+        }
+
         private void AddOriginToResult(string origin, CorsPolicy policy, CorsResult result)
         {
             if (policy.AllowAnyOrigin)
@@ -228,7 +239,7 @@ namespace Microsoft.AspNet.Cors.Infrastructure
                     result.AllowedOrigin = CorsConstants.AnyOrigin;
                 }
             }
-            else if (policy.Origins.Contains(origin))
+            else
             {
                 result.AllowedOrigin = origin;
             }
@@ -245,6 +256,40 @@ namespace Microsoft.AspNet.Cors.Infrastructure
             {
                 target.Add(current);
             }
+        }
+
+        private bool IsWildCardSubdomainMatch(string origin, CorsPolicy policy)
+        {
+            foreach (var o in policy.Origins)
+            {
+                if (!o.Contains("*"))
+                    continue;
+
+                //CANNOT USE System.Text.RegularExpression since it does not exist in .net platform 5.4 (which the project.json targets)
+                // '*' char is not valid for creation of a URI object so we replace it just for this comparison
+                var allowedOriginUri = new Uri(o.Replace("*", "SOMELETTERS"));
+                var actualOriginUri = new Uri(origin);
+                if (allowedOriginUri.Scheme == actualOriginUri.Scheme &&
+                    GetRootDomain(allowedOriginUri) == GetRootDomain(actualOriginUri))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private string GetRootDomain(Uri uri)
+        {
+            //Got this snippet here http://stackoverflow.com/questions/16473838/get-domain-name-of-a-url-in-c-sharp-net
+            var host = uri.Host;
+            int index = host.LastIndexOf('.'), last = 3;
+
+            while (index > 0 && index >= last - 3)
+            {
+                last = index;
+                index = host.LastIndexOf('.', last - 1);
+            }
+
+            return host.Substring(index + 1);
         }
     }
 }

--- a/src/Microsoft.AspNet.Cors/CorsService.cs
+++ b/src/Microsoft.AspNet.Cors/CorsService.cs
@@ -260,17 +260,19 @@ namespace Microsoft.AspNet.Cors.Infrastructure
 
         private bool IsWildCardSubdomainMatch(string origin, CorsPolicy policy)
         {
+            //CANNOT USE System.Text.RegularExpression since it does not exist in .net platform 5.4 (which the project.json targets)
+            // '*' char is not valid for creation of a URI object so we replace it just for this comparison
+            var actualOriginUri = new Uri(origin);
+            var actualOriginRootDomain = GetRootDomain(actualOriginUri);
+
             foreach (var o in policy.Origins)
             {
                 if (!o.Contains("*"))
                     continue;
 
-                //CANNOT USE System.Text.RegularExpression since it does not exist in .net platform 5.4 (which the project.json targets)
-                // '*' char is not valid for creation of a URI object so we replace it just for this comparison
                 var allowedOriginUri = new Uri(o.Replace("*", "SOMELETTERS"));
-                var actualOriginUri = new Uri(origin);
                 if (allowedOriginUri.Scheme == actualOriginUri.Scheme &&
-                    GetRootDomain(allowedOriginUri) == GetRootDomain(actualOriginUri))
+                    actualOriginRootDomain == GetRootDomain(allowedOriginUri))
                     return true;
             }
 

--- a/src/Microsoft.AspNet.Cors/project.json
+++ b/src/Microsoft.AspNet.Cors/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-*",
+  "version": "6.0.0-rc1-final",
   "repository": {
     "type": "git",
     "url": "https://github.com/aspnet/cors"
@@ -9,10 +9,10 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.AspNet.Http.Extensions": "1.0.0-*",
-    "Microsoft.Extensions.Configuration.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.OptionsModel": "1.0.0-*"
+    "Microsoft.AspNet.Http.Extensions": "1.0.0-rc1-final",
+    "Microsoft.Extensions.Configuration.Abstractions": "1.0.0-rc1-final",
+    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-rc1-final",
+    "Microsoft.Extensions.OptionsModel": "1.0.0-rc1-final"
   },
   "frameworks": {
     "net451": {},

--- a/test/Microsoft.AspNet.Cors.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNet.Cors.Test/CorsServiceTests.cs
@@ -872,7 +872,90 @@ namespace Microsoft.AspNet.Cors.Infrastructure
             Assert.Equal("30", httpContext.Response.Headers["Access-Control-Max-Age"]);
         }
 
+        #region Wildcard Subdomain
 
+        [Fact]
+        public void EvaluatePolicy_WildCardSubdomain_MatchOnRoot_ReturnsValidResult()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "http://example.com");
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://*.example.com");
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.Equal("http://example.com", result.AllowedOrigin);
+        }
+
+        [Fact]
+        public void EvaluatePolicy_WildCardSubdomain_MatchOnSubdomainAndRoot_ReturnsValidResult()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "http://abcd.example.com");
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://*.example.com");
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.Equal("http://abcd.example.com", result.AllowedOrigin);
+        }
+
+        [Fact]
+        public void EvaluatePolicy_WildCardSubdomain_MatchOnMultiSubdomains_ReturnsValidResult()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "http://a.b.c.d.example.com");
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://*.example.com");
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.Equal("http://a.b.c.d.example.com", result.AllowedOrigin);
+        }
+
+        [Fact]
+        public void EvaluatePolicy_WildCardSubdomain_NoMatchOnRoot_ReturnsInvalidResult()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "http://a.anotherdomain.com");
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://*.example.com");
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.Null(result.AllowedOrigin);
+
+        }
+
+        [Fact]
+        public void EvaluatePolicy_WildCardSubdomain_NoMatchOnScheme_ReturnsInvalidResult()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "https://a.example.com");//https
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://*.example.com");//http
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.Null(result.AllowedOrigin);
+        }
+
+        #endregion
 
         private static HttpContext GetHttpContext(
             string method = null,

--- a/test/Microsoft.AspNet.Cors.Test/project.json
+++ b/test/Microsoft.AspNet.Cors.Test/project.json
@@ -1,17 +1,17 @@
-﻿{
-    "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.AspNet.Cors": "6.0.0-*",
-        "Microsoft.AspNet.TestHost": "1.0.0-*",
-        "Moq": "4.2.1312.1622",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
-    },
-    "commands": {
-        "test": "xunit.runner.aspnet"
-    },
-    "frameworks": {
-        "dnx451": {
-            "dependencies": {}
-        }
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
+    "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
+    "Moq": "4.2.1312.1622",
+    "xunit.runner.aspnet": "2.0.0-aspnet-rc1-final"
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  },
+  "frameworks": {
+    "dnx451": {
+      "dependencies": {}
     }
+  }
 }


### PR DESCRIPTION
-Ability to allow cors on wildcard subdomain matches like so...
-policy.Origins.Add("http://*.example.com"); //Allows all sudomains of example.com
