### PR TITLE
Include VaryByOrigin when there are multiple Origins configured

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsService.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsService.cs
@@ -245,6 +245,11 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             else if (policy.Origins.Contains(origin))
             {
                 result.AllowedOrigin = origin;
+
+                if(policy.Origins.Count > 1)
+                {
+                    result.VaryByOrigin = true;
+                }
             }
         }
 

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
@@ -881,6 +881,24 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.Equal("30", httpContext.Response.Headers["Access-Control-Max-Age"]);
         }
 
+        [Fact]
+        public void EvaluatePolicy_MultiOriginsPolicy_ReturnsVaryByOriginHeader()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "http://example.com");
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://example.com");
+            policy.Origins.Add("bar");
+
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
+
+            // Assert
+            Assert.NotNull(result.AllowedOrigin);
+            Assert.True(result.VaryByOrigin);
+        }
+
 
 
         private static HttpContext GetHttpContext(

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
@@ -899,26 +899,26 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.True(result.VaryByOrigin);
         }
 
-		[Fact]
-		public void EvaluatePolicy_MultiOriginsPolicy_NoMatchingOrigin_ReturnsInvalidResult()
-		{
-			// Arrange
-			var corsService = new CorsService(new TestCorsOptions());
-			var requestContext = GetHttpContext(origin: "http://example.com");
-			var policy = new CorsPolicy();
-			policy.Origins.Add("http://example-two.com");
-			policy.Origins.Add("http://example-three.com");
+        [Fact]
+        public void EvaluatePolicy_MultiOriginsPolicy_NoMatchingOrigin_ReturnsInvalidResult()
+        {
+            // Arrange
+            var corsService = new CorsService(new TestCorsOptions());
+            var requestContext = GetHttpContext(origin: "http://example.com");
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://example-two.com");
+            policy.Origins.Add("http://example-three.com");
 
-			// Act
-			var result = corsService.EvaluatePolicy(requestContext, policy);
+            // Act
+            var result = corsService.EvaluatePolicy(requestContext, policy);
 
-			// Assert
-			Assert.Null(result.AllowedOrigin);
-			Assert.False(result.VaryByOrigin);
-		}
+            // Assert
+            Assert.Null(result.AllowedOrigin);
+            Assert.False(result.VaryByOrigin);
+        }
 
 
-		private static HttpContext GetHttpContext(
+        private static HttpContext GetHttpContext(
             string method = null,
             string origin = null,
             string accessControlRequestMethod = null,

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
@@ -889,7 +889,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             var requestContext = GetHttpContext(origin: "http://example.com");
             var policy = new CorsPolicy();
             policy.Origins.Add("http://example.com");
-            policy.Origins.Add("bar");
+            policy.Origins.Add("http://example-two.com");
 
             // Act
             var result = corsService.EvaluatePolicy(requestContext, policy);
@@ -899,9 +899,26 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.True(result.VaryByOrigin);
         }
 
+		[Fact]
+		public void EvaluatePolicy_MultiOriginsPolicy_NoMatchingOrigin_ReturnsInvalidResult()
+		{
+			// Arrange
+			var corsService = new CorsService(new TestCorsOptions());
+			var requestContext = GetHttpContext(origin: "http://example.com");
+			var policy = new CorsPolicy();
+			policy.Origins.Add("http://example-two.com");
+			policy.Origins.Add("http://example-three.com");
+
+			// Act
+			var result = corsService.EvaluatePolicy(requestContext, policy);
+
+			// Assert
+			Assert.Null(result.AllowedOrigin);
+			Assert.False(result.VaryByOrigin);
+		}
 
 
-        private static HttpContext GetHttpContext(
+		private static HttpContext GetHttpContext(
             string method = null,
             string origin = null,
             string accessControlRequestMethod = null,


### PR DESCRIPTION
The Vary: Origin header is currently only returned when AllowAnyOrigin and SupportsCredentials is true
When AllowAnyOrigin is not set and there is a origin match for the request, the AllowedOrigin is returned but without the VaryByOrigin header.
That's not a problem when only 1 Origin is configured, but when there are multiple Origins configured, the VaryByOrigin should also be returned.
