### PR TITLE
Inject ICorsPolicyProvider instance through Invoke

### DIFF
--- a/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
@@ -253,14 +253,13 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             var middleware = new CorsMiddleware(
                 Mock.Of<RequestDelegate>(),
                 corsService,
-                mockProvider.Object,
                 policyName: null);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers.Add(CorsConstants.Origin, new[] { "http://example.com" });
 
             // Act
-            await middleware.Invoke(httpContext);
+            await middleware.Invoke(httpContext, mockProvider.Object);
 
             // Assert
             mockProvider.Verify(
@@ -281,14 +280,13 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             var middleware = new CorsMiddleware(
                 Mock.Of<RequestDelegate>(),
                 corsService,
-                mockProvider.Object,
                 policyName: null);
 
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers.Add(CorsConstants.Origin, new[] { "http://example.com" });
 
             // Act
-            await middleware.Invoke(httpContext);
+            await middleware.Invoke(httpContext, mockProvider.Object);
 
             // Assert
             Assert.Equal(200, httpContext.Response.StatusCode);


### PR DESCRIPTION
This allows for scoped instances of `ICorsPolicyProvider` to be injected in the CORS middleware and prevents turning them into singletons.

Resolves #105