### PR TITLE
Fix duplicate header names

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Cors.Infrastructure
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <summary>
         /// The HTTP method for the CORS preflight request.
         /// </summary>        
-        public static readonly string PreflightHttpMethod = "OPTIONS";
+        public static readonly string PreflightHttpMethod = HttpMethods.Options;
 
         /// <summary>
         /// The Origin request header.
@@ -86,9 +87,9 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
         internal static readonly string[] SimpleMethods =
         {
-            "GET",
-            "HEAD",
-            "POST"
+            HttpMethods.Get,
+            HttpMethods.Head,
+            HttpMethods.Post
         };
     }
 }

--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Net.Http.Headers;
+
 namespace Microsoft.AspNetCore.Cors.Infrastructure
 {
     /// <summary>
@@ -10,13 +12,13 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
     {
         /// <summary>
         /// The HTTP method for the CORS preflight request.
-        /// </summary>
+        /// </summary>        
         public static readonly string PreflightHttpMethod = "OPTIONS";
 
         /// <summary>
         /// The Origin request header.
         /// </summary>
-        public static readonly string Origin = "Origin";
+        public static readonly string Origin = HeaderNames.Origin;
 
         /// <summary>
         /// The value for the Access-Control-Allow-Origin response header to allow all origins.
@@ -26,59 +28,60 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <summary>
         /// The Access-Control-Request-Method request header.
         /// </summary>
-        public static readonly string AccessControlRequestMethod = "Access-Control-Request-Method";
+        public static readonly string AccessControlRequestMethod = HeaderNames.AccessControlRequestMethod;
 
         /// <summary>
         /// The Access-Control-Request-Headers request header.
         /// </summary>
-        public static readonly string AccessControlRequestHeaders = "Access-Control-Request-Headers";
+        public static readonly string AccessControlRequestHeaders = HeaderNames.AccessControlRequestHeaders;
 
         /// <summary>
         /// The Access-Control-Allow-Origin response header.
         /// </summary>
-        public static readonly string AccessControlAllowOrigin = "Access-Control-Allow-Origin";
+        public static readonly string AccessControlAllowOrigin = HeaderNames.AccessControlAllowOrigin;
 
         /// <summary>
         /// The Access-Control-Allow-Headers response header.
         /// </summary>
-        public static readonly string AccessControlAllowHeaders = "Access-Control-Allow-Headers";
+        public static readonly string AccessControlAllowHeaders = HeaderNames.AccessControlAllowHeaders;
 
         /// <summary>
         /// The Access-Control-Expose-Headers response header.
         /// </summary>
-        public static readonly string AccessControlExposeHeaders = "Access-Control-Expose-Headers";
+        public static readonly string AccessControlExposeHeaders = HeaderNames.AccessControlExposeHeaders;
 
         /// <summary>
         /// The Access-Control-Allow-Methods response header.
         /// </summary>
-        public static readonly string AccessControlAllowMethods = "Access-Control-Allow-Methods";
+        public static readonly string AccessControlAllowMethods = HeaderNames.AccessControlAllowMethods;
 
         /// <summary>
         /// The Access-Control-Allow-Credentials response header.
         /// </summary>
-        public static readonly string AccessControlAllowCredentials = "Access-Control-Allow-Credentials";
+        public static readonly string AccessControlAllowCredentials = HeaderNames.AccessControlAllowCredentials;
 
         /// <summary>
         /// The Access-Control-Max-Age response header.
         /// </summary>
-        public static readonly string AccessControlMaxAge = "Access-Control-Max-Age";
+        public static readonly string AccessControlMaxAge = HeaderNames.AccessControlMaxAge;
+
 
         internal static readonly string[] SimpleRequestHeaders =
         {
-            "Origin",
-            "Accept",
-            "Accept-Language",
-            "Content-Language",
+            HeaderNames.Origin,
+            HeaderNames.Accept,
+            HeaderNames.AcceptLanguage,
+            HeaderNames.ContentLanguage,
         };
 
         internal static readonly string[] SimpleResponseHeaders =
         {
-            "Cache-Control",
-            "Content-Language",
-            "Content-Type",
-            "Expires",
-            "Last-Modified",
-            "Pragma"
+            HeaderNames.CacheControl,
+            HeaderNames.ContentLanguage,
+            HeaderNames.ContentType,
+            HeaderNames.Expires,
+            HeaderNames.LastModified,
+            HeaderNames.Pragma
         };
 
         internal static readonly string[] SimpleMethods =

--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
     {
         /// <summary>
         /// The HTTP method for the CORS preflight request.
-        /// </summary>        
+        /// </summary>
         public static readonly string PreflightHttpMethod = HttpMethods.Options;
 
         /// <summary>


### PR DESCRIPTION
This uses http header and method names from strings defined in [HeaderNames](https://github.com/aspnet/HttpAbstractions/blob/dev/src/Microsoft.Net.Http.Headers/HeaderNames.cs) and [HttpMethods](https://github.com/aspnet/HttpAbstractions/blob/dev/src/Microsoft.AspNetCore.Http.Abstractions/HttpMethods.cs) respectively.

Resolves aspnet/home#2319