### PR TITLE
No CORS headers sent if Exception is thrown

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Cors.Infrastructure
@@ -18,6 +19,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         private readonly ICorsPolicyProvider _corsPolicyProvider;
         private readonly CorsPolicy _policy;
         private readonly string _corsPolicyName;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Instantiates a new <see cref="CorsMiddleware"/>.
@@ -25,11 +27,13 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
         /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
         public CorsMiddleware(
             RequestDelegate next,
             ICorsService corsService,
-            ICorsPolicyProvider policyProvider)
-            : this(next, corsService, policyProvider, policyName: null)
+            ICorsPolicyProvider policyProvider,
+            ILoggerFactory loggerFactory)
+            : this(next, corsService, policyProvider, loggerFactory, policyName: null)
         {
         }
 
@@ -39,12 +43,15 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
         /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
         /// <param name="policyName">An optional name of the policy to be fetched.</param>
         public CorsMiddleware(
             RequestDelegate next,
             ICorsService corsService,
             ICorsPolicyProvider policyProvider,
-            string policyName)
+            ILoggerFactory loggerFactory,
+            string policyName
+            )
         {
             if (next == null)
             {
@@ -61,10 +68,15 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 throw new ArgumentNullException(nameof(policyProvider));
             }
 
+            if (loggerFactory == null) {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             _next = next;
             _corsService = corsService;
             _corsPolicyProvider = policyProvider;
             _corsPolicyName = policyName;
+            _logger = loggerFactory.CreateLogger<CorsMiddleware>();
         }
 
         /// <summary>
@@ -73,10 +85,12 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
         /// <param name="policy">An instance of the <see cref="CorsPolicy"/> which can be applied.</param>
+        /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
         public CorsMiddleware(
-           RequestDelegate next,
-           ICorsService corsService,
-           CorsPolicy policy)
+            RequestDelegate next,
+            ICorsService corsService,
+            CorsPolicy policy,
+            ILoggerFactory loggerFactory)
         {
             if (next == null)
             {
@@ -93,9 +107,14 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 throw new ArgumentNullException(nameof(policy));
             }
 
+            if (loggerFactory == null) {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             _next = next;
             _corsService = corsService;
             _policy = policy;
+            _logger = loggerFactory.CreateLogger<CorsMiddleware>();
         }
 
         /// <inheritdoc />
@@ -123,8 +142,15 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                     }
                     else
                     {
-                        context.Response.OnStarting(_ => {
-                            ApplyCorsHeaders(context, corsPolicy);
+                        context.Response.OnStarting(c => {
+                            try
+                            {
+                                ApplyCorsHeaders((HttpContext)c, corsPolicy);
+                            }
+                            catch (Exception e)
+                            {
+                                _logger.Log(LogLevel.Error, e, "Applying CORS headers to response failed");
+                            }
                             return Task.CompletedTask;
                         }, context);
                     }

--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
@@ -191,17 +191,19 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                     }
                     else
                     {
-                        context.Response.OnStarting(c => {
+                        context.Response.OnStarting(state =>
+                        {
+                            var (httpContext, policy) = (Tuple<HttpContext, CorsPolicy>)state;
                             try
                             {
-                                ApplyCorsHeaders((HttpContext)c, corsPolicy);
+                                ApplyCorsHeaders(httpContext, policy);
                             }
                             catch (Exception e)
                             {
                                 _logger.Log(LogLevel.Error, e, "Applying CORS headers to response failed");
                             }
                             return Task.CompletedTask;
-                        }, context);
+                        }, Tuple.Create(context, corsPolicy));
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Cors.Infrastructure
@@ -20,6 +21,54 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         private readonly CorsPolicy _policy;
         private readonly string _corsPolicyName;
         private readonly ILogger _logger;
+
+        /// <summary>
+        /// Instantiates a new <see cref="CorsMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
+        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
+        public CorsMiddleware(
+            RequestDelegate next,
+            ICorsService corsService,
+            ICorsPolicyProvider policyProvider)
+            : this(next, corsService, policyProvider, NullLoggerFactory.Instance, policyName: null)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="CorsMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
+        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        /// <param name="policyName">An optional name of the policy to be fetched.</param>
+        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
+        public CorsMiddleware(
+            RequestDelegate next,
+            ICorsService corsService,
+            ICorsPolicyProvider policyProvider,
+            string policyName
+            )
+            : this(next, corsService, policyProvider, NullLoggerFactory.Instance, policyName)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="CorsMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
+        /// <param name="policy">An instance of the <see cref="CorsPolicy"/> which can be applied.</param>
+        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
+        public CorsMiddleware(
+            RequestDelegate next,
+            ICorsService corsService,
+            CorsPolicy policy)
+            : this(next, corsService, policy, NullLoggerFactory.Instance)
+        {
+        }
 
         /// <summary>
         /// Instantiates a new <see cref="CorsMiddleware"/>.

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -246,6 +247,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             // Arrange
             var corsService = Mock.Of<ICorsService>();
             var mockProvider = new Mock<ICorsPolicyProvider>();
+            var loggerFactory = Mock.Of<ILoggerFactory>();
             mockProvider.Setup(o => o.GetPolicyAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
                 .Returns(Task.FromResult<CorsPolicy>(null))
                 .Verifiable();
@@ -254,6 +256,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 Mock.Of<RequestDelegate>(),
                 corsService,
                 mockProvider.Object,
+                loggerFactory,
                 policyName: null);
 
             var httpContext = new DefaultHttpContext();
@@ -274,6 +277,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             // Arrange
             var corsService = Mock.Of<ICorsService>();
             var mockProvider = new Mock<ICorsPolicyProvider>();
+            var loggerFactory = Mock.Of<ILoggerFactory>();
             mockProvider.Setup(o => o.GetPolicyAsync(It.IsAny<HttpContext>(), It.IsAny<string>()))
                 .Returns(Task.FromResult<CorsPolicy>(null))
                 .Verifiable();
@@ -282,6 +286,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 Mock.Of<RequestDelegate>(),
                 corsService,
                 mockProvider.Object,
+                loggerFactory,
                 policyName: null);
 
             var httpContext = new DefaultHttpContext();


### PR DESCRIPTION
Normally headers are added however if a controller throws an exception then CORS headers not be present.

All matching responses should have CORS headers added. This problem affects the use of middleware (including the UseExceptionHandler middleware).

This PR fixes the issue by moving the adding of the headers to `Response.OnStarting`.

https://github.com/aspnet/Home/issues/2378
https://github.com/aspnet/Home/issues/3220