### PR TITLE
No CORS headers sent if Exception is thrown

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Cors.Internal;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Cors.Infrastructure
@@ -18,6 +21,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         private readonly ICorsPolicyProvider _corsPolicyProvider;
         private readonly CorsPolicy _policy;
         private readonly string _corsPolicyName;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Instantiates a new <see cref="CorsMiddleware"/>.
@@ -25,11 +29,12 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
         /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
         public CorsMiddleware(
             RequestDelegate next,
             ICorsService corsService,
             ICorsPolicyProvider policyProvider)
-            : this(next, corsService, policyProvider, policyName: null)
+            : this(next, corsService, policyProvider, NullLoggerFactory.Instance, policyName: null)
         {
         }
 
@@ -40,10 +45,60 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
         /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
         /// <param name="policyName">An optional name of the policy to be fetched.</param>
+        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
         public CorsMiddleware(
             RequestDelegate next,
             ICorsService corsService,
             ICorsPolicyProvider policyProvider,
+            string policyName)
+            : this(next, corsService, policyProvider, NullLoggerFactory.Instance, policyName)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="CorsMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
+        /// <param name="policy">An instance of the <see cref="CorsPolicy"/> which can be applied.</param>
+        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
+        public CorsMiddleware(
+            RequestDelegate next,
+            ICorsService corsService,
+            CorsPolicy policy)
+            : this(next, corsService, policy, NullLoggerFactory.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="CorsMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
+        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
+        public CorsMiddleware(
+            RequestDelegate next,
+            ICorsService corsService,
+            ICorsPolicyProvider policyProvider,
+            ILoggerFactory loggerFactory)
+            : this(next, corsService, policyProvider, loggerFactory, policyName: null)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="CorsMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The next middleware in the pipeline.</param>
+        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
+        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
+        /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
+        /// <param name="policyName">An optional name of the policy to be fetched.</param>
+        public CorsMiddleware(
+            RequestDelegate next,
+            ICorsService corsService,
+            ICorsPolicyProvider policyProvider,
+            ILoggerFactory loggerFactory,
             string policyName)
         {
             if (next == null)
@@ -61,10 +116,16 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 throw new ArgumentNullException(nameof(policyProvider));
             }
 
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             _next = next;
             _corsService = corsService;
             _corsPolicyProvider = policyProvider;
             _corsPolicyName = policyName;
+            _logger = loggerFactory.CreateLogger<CorsMiddleware>();
         }
 
         /// <summary>
@@ -73,10 +134,12 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
         /// <param name="policy">An instance of the <see cref="CorsPolicy"/> which can be applied.</param>
+        /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
         public CorsMiddleware(
-           RequestDelegate next,
-           ICorsService corsService,
-           CorsPolicy policy)
+            RequestDelegate next,
+            ICorsService corsService,
+            CorsPolicy policy,
+            ILoggerFactory loggerFactory)
         {
             if (next == null)
             {
@@ -93,9 +156,15 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 throw new ArgumentNullException(nameof(policy));
             }
 
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
             _next = next;
             _corsService = corsService;
             _policy = policy;
+            _logger = loggerFactory.CreateLogger<CorsMiddleware>();
         }
 
         /// <inheritdoc />
@@ -106,9 +175,6 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 var corsPolicy = _policy ?? await _corsPolicyProvider?.GetPolicyAsync(context, _corsPolicyName);
                 if (corsPolicy != null)
                 {
-                    var corsResult = _corsService.EvaluatePolicy(context, corsPolicy);
-                    _corsService.ApplyResult(corsResult, context.Response);
-
                     var accessControlRequestMethod =
                         context.Request.Headers[CorsConstants.AccessControlRequestMethod];
                     if (string.Equals(
@@ -117,15 +183,39 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                             StringComparison.OrdinalIgnoreCase) &&
                             !StringValues.IsNullOrEmpty(accessControlRequestMethod))
                     {
+                        ApplyCorsHeaders(context, corsPolicy);
+
                         // Since there is a policy which was identified,
                         // always respond to preflight requests.
                         context.Response.StatusCode = StatusCodes.Status204NoContent;
                         return;
                     }
+                    else
+                    {
+                        context.Response.OnStarting(state =>
+                        {
+                            var (httpContext, policy) = (Tuple<HttpContext, CorsPolicy>)state;
+                            try
+                            {
+                                ApplyCorsHeaders(httpContext, policy);
+                            }
+                            catch (Exception exception)
+                            {
+                                _logger.FailedToSetCorsHeaders(exception);
+                            }
+                            return Task.CompletedTask;
+                        }, Tuple.Create(context, corsPolicy));
+                    }
                 }
             }
 
             await _next(context);
+        }
+
+        private void ApplyCorsHeaders(HttpContext context, CorsPolicy corsPolicy)
+        {
+            var corsResult = _corsService.EvaluatePolicy(context, corsPolicy);
+            _corsService.ApplyResult(corsResult, context.Response);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Cors/Internal/CORSLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Cors/Internal/CORSLoggerExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNetCore.Cors.Internal
         private static readonly Action<ILogger, string, Exception> _originNotAllowed;
         private static readonly Action<ILogger, string, Exception> _accessControlMethodNotAllowed;
         private static readonly Action<ILogger, string, Exception> _requestHeaderNotAllowed;
+        private static readonly Action<ILogger, Exception> _failedToSetCorsHeaders;
 
         static CORSLoggerExtensions()
         {
@@ -58,6 +59,11 @@ namespace Microsoft.AspNetCore.Cors.Internal
                 LogLevel.Information,
                 8,
                 "Request header '{requestHeader}' not allowed in CORS policy.");
+
+            _failedToSetCorsHeaders = LoggerMessage.Define(
+                LogLevel.Warning,
+                9,
+                "Failed to apply CORS Response headers.");
         }
 
         public static void IsPreflightRequest(this ILogger logger)
@@ -98,6 +104,11 @@ namespace Microsoft.AspNetCore.Cors.Internal
         public static void RequestHeaderNotAllowed(this ILogger logger, string requestHeader)
         {
             _requestHeaderNotAllowed(logger, requestHeader, null);
+        }
+
+        public static void FailedToSetCorsHeaders(this ILogger logger, Exception exception)
+        {
+            _failedToSetCorsHeaders(logger, exception);
         }
     }
 }


### PR DESCRIPTION
- Normally headers are added however if a controller throws an exception then CORS headers not be present.

Addresses aspnet/Home#3220