### PR TITLE
Fixed preflight simple request issue with content-type.

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsResult.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsResult.cs
@@ -45,6 +45,11 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         public bool VaryByOrigin { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating if 'Simple methods' should be filtered.
+        /// </summary>
+        public bool FilterSimpleMethods { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the <see cref="TimeSpan"/> for which the results of a preflight request can be cached.
         /// </summary>
         public TimeSpan? PreflightMaxAge

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsServiceTests.cs
@@ -1122,6 +1122,32 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             Assert.False(result.VaryByOrigin);
         }
 
+        [Fact]
+        public void EvaluatePreflightRequest_SimpleAllowMethods_AllowMethodsHeaderAddedForSimpleMethodsWithContentType()
+        {
+            // Arrange
+            var httpContext
+                = GetHttpContext(
+                    origin: "http://example.com",
+                    accessControlRequestHeaders: new string[] { "Content-Type" },
+                    accessControlRequestMethod: "GET");
+
+            var service = new CorsService(new TestCorsOptions());
+            var result = new CorsResult();
+            var policy = new CorsPolicy();
+            policy.Origins.Add("http://example.com");
+            policy.Methods.Add("GET");
+            policy.Headers.Add("Content-Type");
+
+            // Act
+            service.EvaluatePreflightRequest(httpContext, policy, result);
+
+            // Assert
+            Assert.False(result.FilterSimpleMethods);
+            Assert.Contains("GET", result.AllowedMethods);
+            Assert.Contains("Content-Type", result.AllowedHeaders);
+        }
+
 
         private static HttpContext GetHttpContext(
             string method = null,


### PR DESCRIPTION
This merge fixes issue aspnet/Home/issues/3323

As explained in the issue I've found that the options method does not return any `Access-Control-Allow-Method` header for GET/POST or HEAD, though Angular requires it. Doing a bit more research I've found the following (requoted from issue comment) condition:
>      Or if the Content-Type header has a value other than the following:
>          application/x-www-form-urlencoded
>          multipart/form-data
>          text/plain
Source: [Mozilla dev documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests)
Meaning if the client requires some other value than the specified above it does a preflight check using 'simple methods' `GET/POST or HEAD` but providing a `Access-Control-Request-Headers` header with content-type as value.

So this fix returns if provided the right criteria (Required header and 'simple method') skips the filtering of the 'Simple methods' and handles the request as prescribed in the [Fetch](https://fetch.spec.whatwg.org/) spec.