### PR TITLE
Fixed preflighted simple request issue with content-type.

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsConstants.cs
@@ -65,31 +65,5 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// The Access-Control-Max-Age response header.
         /// </summary>
         public static readonly string AccessControlMaxAge = HeaderNames.AccessControlMaxAge;
-
-
-        internal static readonly string[] SimpleRequestHeaders =
-        {
-            HeaderNames.Origin,
-            HeaderNames.Accept,
-            HeaderNames.AcceptLanguage,
-            HeaderNames.ContentLanguage,
-        };
-
-        internal static readonly string[] SimpleResponseHeaders =
-        {
-            HeaderNames.CacheControl,
-            HeaderNames.ContentLanguage,
-            HeaderNames.ContentType,
-            HeaderNames.Expires,
-            HeaderNames.LastModified,
-            HeaderNames.Pragma
-        };
-
-        internal static readonly string[] SimpleMethods =
-        {
-            HttpMethods.Get,
-            HttpMethods.Head,
-            HttpMethods.Post
-        };
     }
 }

--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsService.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsService.cs
@@ -151,8 +151,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             {
                 foreach (var requestHeader in requestHeaders)
                 {
-                    if (!CorsConstants.SimpleRequestHeaders.Contains(requestHeader, StringComparer.OrdinalIgnoreCase) &&
-                                                  !policy.Headers.Contains(requestHeader, StringComparer.OrdinalIgnoreCase))
+                    if (!policy.Headers.Contains(requestHeader, StringComparer.OrdinalIgnoreCase))
                     {
                         _logger?.PolicyFailure();
                         _logger?.RequestHeaderNotAllowed(requestHeader);
@@ -201,50 +200,23 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
             if (result.AllowedMethods.Count > 0)
             {
-                // Filter out simple methods
-                var nonSimpleAllowMethods = result.AllowedMethods
-                    .Where(m =>
-                        !CorsConstants.SimpleMethods.Contains(m, StringComparer.OrdinalIgnoreCase))
-                    .ToArray();
-
-                if (nonSimpleAllowMethods.Length > 0)
-                {
-                    headers.SetCommaSeparatedValues(
-                        CorsConstants.AccessControlAllowMethods,
-                        nonSimpleAllowMethods);
-                }
+                headers.SetCommaSeparatedValues(
+                    CorsConstants.AccessControlAllowMethods,
+                    result.AllowedMethods.ToArray());
             }
 
             if (result.AllowedHeaders.Count > 0)
             {
-                // Filter out simple request headers
-                var nonSimpleAllowRequestHeaders = result.AllowedHeaders
-                    .Where(header =>
-                        !CorsConstants.SimpleRequestHeaders.Contains(header, StringComparer.OrdinalIgnoreCase))
-                    .ToArray();
-
-                if (nonSimpleAllowRequestHeaders.Length > 0)
-                {
-                    headers.SetCommaSeparatedValues(
-                        CorsConstants.AccessControlAllowHeaders,
-                        nonSimpleAllowRequestHeaders);
-                }
+                headers.SetCommaSeparatedValues(
+                    CorsConstants.AccessControlAllowHeaders,
+                    result.AllowedHeaders.ToArray());
             }
 
             if (result.AllowedExposedHeaders.Count > 0)
             {
-                // Filter out simple response headers
-                var nonSimpleAllowResponseHeaders = result.AllowedExposedHeaders
-                    .Where(header =>
-                        !CorsConstants.SimpleResponseHeaders.Contains(header, StringComparer.OrdinalIgnoreCase))
-                    .ToArray();
-
-                if (nonSimpleAllowResponseHeaders.Length > 0)
-                {
-                    headers.SetCommaSeparatedValues(
-                        CorsConstants.AccessControlExposeHeaders,
-                        nonSimpleAllowResponseHeaders);
-                }
+                headers.SetCommaSeparatedValues(
+                    CorsConstants.AccessControlExposeHeaders,
+                    result.AllowedExposedHeaders.ToArray());
             }
 
             if (result.PreflightMaxAge.HasValue)


### PR DESCRIPTION
This merge fixes issue aspnet/Home/issues/3323

As explained in the issue I've found that the options method does not return any `Access-Control-Allow-Method` header for GET/POST or HEAD, though Angular requires it. Doing a bit more research I've found the following (requoted from issue comment) condition:
>      Or if the Content-Type header has a value other than the following:
>          application/x-www-form-urlencoded
>          multipart/form-data
>          text/plain
Source: [Mozilla dev documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests)
Meaning if the client requires some other value than the specified above it does a preflight check using 'simple methods' `GET/POST or HEAD` but providing a `Access-Control-Request-Headers` header with content-type as value.

So this fix returns if provided the right criteria (Required header and 'simple method') skips the filtering of the 'Simple methods' and handles the request as prescribed in the [Fetch](https://fetch.spec.whatwg.org/) spec.