### PR TITLE
Added override for VaryByOrigin when using asterisk.

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsService.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsService.cs
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             {
                 result.AllowedOrigin = origin;
 
-                if(policy.Origins.Count > 1)
+                if(policy.Origins.Count > 1 || policy.Origins.Any(o => o.Contains("*")))
                 {
                     result.VaryByOrigin = true;
                 }


### PR DESCRIPTION
Originating issue aspnet/Home/issues/3299.

This fix allows clients to use the following 2 approaches allow the enabling of the Vary: 'Origin' header when using an asterisk in the `WithOrigins()` function for the `CorsPolicyBuilder`
```csharp 
services.AddCors(options =>
{
    options.AddPolicy("Policy1",
        builder => builder
            .WithOrigins("*")
            .SetIsOriginAllowed(IsOriginAllowed(env))
    );
});
```

And even single origin domains using a wildcard:
```csharp
services.AddCors(options =>
{
    options.AddPolicy("Policy1",
        builder => builder
            .WithOrigins("*.domain.com")
    );
});
```

Without having to do a hacky workaround like described in the issue above.

This should be an easy fix with low to none conflicts.
