### PR TITLE
Inject ICorsPolicyProvider instance through Invoke

### DIFF
--- a/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Cors/Infrastructure/CorsMiddleware.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
     {
         private readonly Func<object, Task> OnResponseStartingDelegate = OnResponseStarting;
         private readonly RequestDelegate _next;
-        private readonly ICorsPolicyProvider _corsPolicyProvider;
         private readonly CorsPolicy _policy;
         private readonly string _corsPolicyName;
 
@@ -26,61 +25,12 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// </summary>
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
-        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
-        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
-        public CorsMiddleware(
-            RequestDelegate next,
-            ICorsService corsService,
-            ICorsPolicyProvider policyProvider)
-            : this(next, corsService, policyProvider, NullLoggerFactory.Instance, policyName: null)
-        {
-        }
-
-        /// <summary>
-        /// Instantiates a new <see cref="CorsMiddleware"/>.
-        /// </summary>
-        /// <param name="next">The next middleware in the pipeline.</param>
-        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
-        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
-        /// <param name="policyName">An optional name of the policy to be fetched.</param>
-        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
-        public CorsMiddleware(
-            RequestDelegate next,
-            ICorsService corsService,
-            ICorsPolicyProvider policyProvider,
-            string policyName)
-            : this(next, corsService, policyProvider, NullLoggerFactory.Instance, policyName)
-        {
-        }
-
-        /// <summary>
-        /// Instantiates a new <see cref="CorsMiddleware"/>.
-        /// </summary>
-        /// <param name="next">The next middleware in the pipeline.</param>
-        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
-        /// <param name="policy">An instance of the <see cref="CorsPolicy"/> which can be applied.</param>
-        [Obsolete("This constructor has been replaced with an equivalent constructor which requires an ILoggerFactory")]
-        public CorsMiddleware(
-            RequestDelegate next,
-            ICorsService corsService,
-            CorsPolicy policy)
-            : this(next, corsService, policy, NullLoggerFactory.Instance)
-        {
-        }
-
-        /// <summary>
-        /// Instantiates a new <see cref="CorsMiddleware"/>.
-        /// </summary>
-        /// <param name="next">The next middleware in the pipeline.</param>
-        /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
-        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
         /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
         public CorsMiddleware(
             RequestDelegate next,
             ICorsService corsService,
-            ICorsPolicyProvider policyProvider,
             ILoggerFactory loggerFactory)
-            : this(next, corsService, policyProvider, loggerFactory, policyName: null)
+            : this(next, corsService, loggerFactory, policyName: null)
         {
         }
 
@@ -89,13 +39,11 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         /// </summary>
         /// <param name="next">The next middleware in the pipeline.</param>
         /// <param name="corsService">An instance of <see cref="ICorsService"/>.</param>
-        /// <param name="policyProvider">A policy provider which can get an <see cref="CorsPolicy"/>.</param>
         /// <param name="loggerFactory">An instance of <see cref="ILoggerFactory"/>.</param>
         /// <param name="policyName">An optional name of the policy to be fetched.</param>
         public CorsMiddleware(
             RequestDelegate next,
             ICorsService corsService,
-            ICorsPolicyProvider policyProvider,
             ILoggerFactory loggerFactory,
             string policyName)
         {
@@ -109,11 +57,6 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
                 throw new ArgumentNullException(nameof(corsService));
             }
 
-            if (policyProvider == null)
-            {
-                throw new ArgumentNullException(nameof(policyProvider));
-            }
-
             if (loggerFactory == null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
@@ -121,7 +64,6 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
 
             _next = next;
             CorsService = corsService;
-            _corsPolicyProvider = policyProvider;
             _corsPolicyName = policyName;
             Logger = loggerFactory.CreateLogger<CorsMiddleware>();
         }
@@ -170,19 +112,19 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
         private ILogger Logger { get; }
 
         /// <inheritdoc />
-        public Task Invoke(HttpContext context)
+        public Task Invoke(HttpContext context, ICorsPolicyProvider corsPolicyProvider)
         {
             if (!context.Request.Headers.ContainsKey(CorsConstants.Origin))
             {
                 return _next(context);
             }
 
-            return InvokeCore(context);
+            return InvokeCore(context, corsPolicyProvider);
         }
 
-        private async Task InvokeCore(HttpContext context)
+        private async Task InvokeCore(HttpContext context, ICorsPolicyProvider corsPolicyProvider)
         {
-            var corsPolicy = _policy ?? await _corsPolicyProvider?.GetPolicyAsync(context, _corsPolicyName);
+            var corsPolicy = _policy ?? await corsPolicyProvider.GetPolicyAsync(context, _corsPolicyName);
             if (corsPolicy == null)
             {
                 Logger?.NoCorsPolicyFound();

--- a/src/Microsoft.AspNetCore.Cors/breakingchanges.netcore.json
+++ b/src/Microsoft.AspNetCore.Cors/breakingchanges.netcore.json
@@ -1,0 +1,22 @@
+[
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Cors.Infrastructure.CorsMiddleware",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.AspNetCore.Cors.Infrastructure.ICorsService corsService, Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy policy)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Cors.Infrastructure.CorsMiddleware",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.AspNetCore.Cors.Infrastructure.ICorsService corsService, Microsoft.AspNetCore.Cors.Infrastructure.ICorsPolicyProvider policyProvider)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Cors.Infrastructure.CorsMiddleware",
+      "MemberId": "public .ctor(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.AspNetCore.Cors.Infrastructure.ICorsService corsService, Microsoft.AspNetCore.Cors.Infrastructure.ICorsPolicyProvider policyProvider, System.String policyName)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.AspNetCore.Cors.Infrastructure.CorsMiddleware",
+      "MemberId": "public System.Threading.Tasks.Task Invoke(Microsoft.AspNetCore.Http.HttpContext context)",
+      "Kind": "Removal"
+    }
+  ]

--- a/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Cors.Test/CorsMiddlewareTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -336,7 +336,6 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             var middleware = new CorsMiddleware(
                 Mock.Of<RequestDelegate>(),
                 corsService,
-                mockProvider.Object,
                 loggerFactory,
                 policyName: null);
 
@@ -344,7 +343,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             httpContext.Request.Headers.Add(CorsConstants.Origin, new[] { "http://example.com" });
 
             // Act
-            await middleware.Invoke(httpContext);
+            await middleware.Invoke(httpContext, mockProvider.Object);
 
             // Assert
             mockProvider.Verify(
@@ -366,7 +365,6 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             var middleware = new CorsMiddleware(
                 Mock.Of<RequestDelegate>(),
                 corsService,
-                mockProvider.Object,
                 loggerFactory,
                 policyName: null);
 
@@ -374,7 +372,7 @@ namespace Microsoft.AspNetCore.Cors.Infrastructure
             httpContext.Request.Headers.Add(CorsConstants.Origin, new[] { "http://example.com" });
 
             // Act
-            await middleware.Invoke(httpContext);
+            await middleware.Invoke(httpContext, mockProvider.Object);
 
             // Assert
             Assert.Equal(200, httpContext.Response.StatusCode);


### PR DESCRIPTION
This allows for scoped instances of `ICorsPolicyProvider` to be injected in the CORS middleware and prevents turning them into singletons.

Resolves https://github.com/aspnet/AspNetCore/issues/2377